### PR TITLE
Docs: Fix index page and change order of menu items

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -10,11 +10,11 @@ geekdocFilePath: _index.md
 ## Abstract
 
 When using oCIS, the requirement to store settings arises. This extension provides functionality
-for other extensions to register new settings within oCIS. It is responsible for saving the respective
+for other extensions to register new settings within oCIS. It is responsible for storing the respective
 settings values as well.
 
 For ease of use, this extension provides an ocis-web extension which allows users to change their settings values.
-Please refer to the [extensions docs](https://owncloud.github.io/ocis/extensions/#external-phoenix-apps)
+Please refer to the [ocis-web extension docs](https://owncloud.github.io/ocis/extensions/#external-phoenix-apps)
 for running ocis-web extensions.
 
 {{< mermaid class="text-center">}}
@@ -32,14 +32,13 @@ graph TD
 {{< /mermaid >}}
 
 The diagram shows how the settings service integrates into oCIS:
-- oCIS extensions can register settings bundles with ocis-settings.
-- The frontend can be plugged into ocis-web, showing generated forms for changing settings values as a user.
+**Settings management:**
+- oCIS extensions can register settings bundles with the ocis-settings service.
+- The settings frontend can be plugged into ocis-web, showing generated forms for changing settings values as a user.
+
+**Settings usage:**
 - Extensions can query ocis-settings for settings values of a user.
 - The ownCloud SDK, used as a data abstraction layer for ocis-web, will query ocis-settings for settings values of a user,
 if it's available. The SDK uses sensible defaults when ocis-settings is not part of the setup.
 
-For compatibility with ownCloud 10, a migration of settings into the storage of ocis-settings will be available.
-
-## Table of Contents
-
-{{< toc-tree >}}
+For compatibility with ownCloud 10, a migration of ownCloud 10 settings into the storage of ocis-settings will be available.

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -1,7 +1,7 @@
 ---
 title: "Settings Bundles"
 date: 2020-05-04T00:00:00+00:00
-weight: 17
+weight: 50
 geekdocRepo: https://github.com/owncloud/ocis-settings
 geekdocEditPath: edit/master/docs
 geekdocFilePath: bundles.md

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,7 +1,7 @@
 ---
 title: "Glossary"
 date: 2020-05-04T12:35:00+01:00
-weight: 15
+weight: 80
 geekdocRepo: https://github.com/owncloud/ocis-settings
 geekdocEditPath: edit/master/docs
 geekdocFilePath: glossary.md

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,7 +1,7 @@
 ---
 title: "License"
 date: 2018-05-02T00:00:00+00:00
-weight: 40
+weight: 90
 geekdocRepo: https://github.com/owncloud/ocis-settings
 geekdocEditPath: edit/master/docs
 geekdocFilePath: license.md


### PR DESCRIPTION
Small fixes as suggested [here](https://github.com/owncloud/ocis-settings/pull/4#issuecomment-623648907).

- remove TOC from index page (was expecting a toc for the full extension docs, doesn't make sense this way)
- change order of menu items