### PR TITLE
[tests-only] don't run vet & lint twice

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -58,39 +58,11 @@ def testing(ctx):
         ],
       },
       {
-        'name': 'vet',
-        'image': 'webhippie/golang:1.13',
-        'pull': 'always',
-        'commands': [
-          'make vet',
-        ],
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/srv/app',
-          },
-        ],
-      },
-      {
-        'name': 'staticcheck',
+        'name': 'golangci-lint',
         'image': 'golangci/golangci-lint:latest',
         'pull': 'always',
         'commands': [
           'golangci-lint run',
-        ],
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/srv/app',
-          },
-        ],
-      },
-      {
-        'name': 'lint',
-        'image': 'webhippie/golang:1.13',
-        'pull': 'always',
-        'commands': [
-          'make lint',
         ],
         'volumes': [
           {


### PR DESCRIPTION
lint & vet are covered by golangci-lint, let's use less :electric_plug: to save the :earth_asia:  