### PR TITLE
Fix fetching value by identifier and system scope values

### DIFF
--- a/changelog/unreleased/fix-system-scope-values.md
+++ b/changelog/unreleased/fix-system-scope-values.md
@@ -1,0 +1,7 @@
+Bugfix: Fix loading and saving system scoped values
+
+We fixed loading and saving system scoped values. Those are now saved without an account uuid, so that the value
+can be loaded by other accounts as well.
+
+https://github.com/owncloud/ocis-settings/pull/66
+

--- a/changelog/unreleased/input-validation.md
+++ b/changelog/unreleased/input-validation.md
@@ -1,0 +1,6 @@
+Bugfix: Complete input validation
+
+There was one handler function without input validation. We implemented the input validation for `ValueService.ReadValueByUniqueIdentifiers`.
+
+https://github.com/owncloud/ocis-settings/pull/66
+

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -216,8 +216,11 @@ func (g Service) GetValue(c context.Context, req *proto.GetValueRequest, res *pr
 }
 
 // GetValueByUniqueIdentifiers implements the ValueService interface
-func (g Service) GetValueByUniqueIdentifiers(ctx context.Context, in *proto.GetValueByUniqueIdentifiersRequest, res *proto.GetValueResponse) error {
-	v, err := g.manager.ReadValueByUniqueIdentifiers(in.AccountUuid, in.SettingId)
+func (g Service) GetValueByUniqueIdentifiers(ctx context.Context, req *proto.GetValueByUniqueIdentifiersRequest, res *proto.GetValueResponse) error {
+	if validationError := validateGetValueByUniqueIdentifiers(req); validationError != nil {
+		return merrors.BadRequest(g.id, "%s", validationError)
+	}
+	v, err := g.manager.ReadValueByUniqueIdentifiers(req.AccountUuid, req.SettingId)
 	if err != nil {
 		return merrors.NotFound(g.id, "%s", err)
 	}

--- a/pkg/service/v0/validator.go
+++ b/pkg/service/v0/validator.go
@@ -91,6 +91,14 @@ func validateGetValue(req *proto.GetValueRequest) error {
 	return validation.Validate(req.Id, is.UUID)
 }
 
+func validateGetValueByUniqueIdentifiers(req *proto.GetValueByUniqueIdentifiersRequest) error {
+	return validation.ValidateStruct(
+		req,
+		validation.Field(&req.SettingId, is.UUID),
+		validation.Field(&req.AccountUuid, requireAccountID...),
+	)
+}
+
 func validateListValues(req *proto.ListValuesRequest) error {
 	return validation.ValidateStruct(
 		req,


### PR DESCRIPTION
There were several small bugs, now fixed in this PR:
- fetching a value by identifier (settingID and accountID) didn't return an error if the value was not found
- saving values for a setting with resource type `TYPE_SYSTEM`, i.e. global value, which are the same value for all users, were saved with an account uuid set. The account uuid must be omitted on global values so that we are allowed to load them for users with another account uuid.
- loading global values also didn't work. looks like the implementation was forgotten...